### PR TITLE
🐛 Update new argument parsing

### DIFF
--- a/commands/updateProfile.js
+++ b/commands/updateProfile.js
@@ -45,6 +45,8 @@ const updateProfile = async (msg) => {
             `Please make sure you have passed the appropriate amount of arguments`
         );
     }
+    const args = parts.filter((p) => !p.startsWith("-"));
+
 
     const discordUsername = msg.author.username;
     const discordId = msg.author.id;
@@ -61,7 +63,7 @@ const updateProfile = async (msg) => {
                 `Please make sure you have passed appropriate flags : [${flags}]`
             );
         }
-        const value = parts[i + 1];
+        const value = args[Number(i / 2).toFixed(0)];
         if (!validFlags[flagName].validate(value)) {
             return await msg.reply(
                 `Please make sure you have passed an appropriate value for the ${flagName} flag. ${validFlags[flagName].validationMessage}`


### PR DESCRIPTION
Fixes #5 
Modified the logic to separately parse flags of the format "-*" and rest as arguments.
```javascript
// Extract arguments separately
// The flags startwith "-" and the rest are arguments
const args = parts.filter((p) => !p.startsWith("-"));
```

```javascript
// Now agrs array contains same number of items as flags i.e. 1/2 of parts
// for each flagName at postion i => The value is at i/2 (floor division)
const value = args[Number(i / 2).toFixed(0)];
```

PS: sorry for the slightly confusing commit message