### PR TITLE
Fix issue where users with no username will cause kudos to not display.

### DIFF
--- a/src/commands/kudosLeaderboard.ts
+++ b/src/commands/kudosLeaderboard.ts
@@ -36,7 +36,7 @@ const createLeaderboardFields = (leaders: Leader[]): EmbedField[] => {
   const fields: EmbedField[] = [];
   for (let i = 0; i < leaders.length; i++) {
     fields.push({
-      name: leaders[i].username,
+      name: leaders[i].username || 'Unknown',
       value: leaders[i].points + '',
     });
   }


### PR DESCRIPTION
Currently if a user doesn't have a profile and they give or receive a kudo we create a profile for them but we don't know their username.
This causes the leaderboard to throw an error when building the embed. All fields must have a value.

For now I think showing Unknow or something similiar is probably best.

We should fix the user upsert to look up the user to at least get the name.
Or use the id to get the names here so we don't need to store them at all.