### PR TITLE
Tweets Failing Infinitely

### DIFF
--- a/src/db/shares.ts
+++ b/src/db/shares.ts
@@ -16,6 +16,7 @@ export const getShareToTweet = async () => {
   const { data, error } = await supabase
     .from(SHARE_TABLE_NAME)
     .select()
+    .order('createdAt', { ascending: false })
     .eq('tweetable', true)
     .eq('tweeted', false)
     .limit(1);

--- a/src/server/routes/shares.ts
+++ b/src/server/routes/shares.ts
@@ -41,7 +41,10 @@ router.get('/nextTweet', async (req: Request, res: Response) => {
       retVal.body.err = 'Something went wrong: (';
     } else {
       const tweet = await getTweetFromShare(share);
-      retVal.body.data = tweet;
+      retVal.body.data = {
+        tweet,
+        share,
+      };
       retVal.status = 200;
     }
   } catch (error) {

--- a/src/tweeter.ts
+++ b/src/tweeter.ts
@@ -7,8 +7,9 @@ import { Share } from './types/types';
 
 const tweetNextShare = async () => {
   console.info('Looking for shares to tweet');
+  let share;
   try {
-    const share = await getShareToTweet();
+    share = await getShareToTweet();
     if (!share) return;
 
     const tweet = await getTweetFromShare(share);
@@ -20,11 +21,17 @@ const tweetNextShare = async () => {
       console.info('Sending tweet');
       await sendTweet(tweet, share.imageUrl || '');
       await sendEmailAlert('Tweet Sent', `Tweet: ${tweet}`);
-      markShareAsTweeted(share.id);
     }
   } catch (err) {
     console.error(err);
     console.error('Something went wrong trying to send a tweet');
+  } finally {
+    //?  mark share as tweeted regardless of if it was successful
+    //? this way we avoid an infinite loop of trying to tweet
+    //? the same one over and over
+    if (share) {
+      await markShareAsTweeted(share.id);
+    }
   }
 };
 


### PR DESCRIPTION
- mark share as tweeted even if tweet fails. This avoids infinite attempts to tweet a share that will fail
- query record to be tweeted based on desc order (tweet the latest record)