### PR TITLE
update highlight sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@highlight-run/node": "^2.5.2",
+        "@highlight-run/node": "^2.5.3",
         "@sendgrid/mail": "^7.7.0",
         "@supabase/supabase-js": "^2.1.3",
         "airtable": "^0.10.1",
@@ -887,9 +887,9 @@
       }
     },
     "node_modules/@highlight-run/node": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@highlight-run/node/-/node-2.5.2.tgz",
-      "integrity": "sha512-/UbU8Zqb7GrMV7Ldc0VvomUK4nPJ+ZjQnU7WQUWEjepE0EGTPB4fSP8eS69S0/OUjC8Z9I/OZqAvUCepkPznQg==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@highlight-run/node/-/node-2.5.3.tgz",
+      "integrity": "sha512-dTAiYSiU+kIDKxRzODzlfSeIUj7xfJtabzMNO2zl22FK3V5n6TPJ4LhfOB0efNiO+avjCEcrdSe/bcTwclHeyQ==",
       "dependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.3.0",
         "@opentelemetry/auto-instrumentations-node": "0.32.1",
@@ -16235,9 +16235,9 @@
       }
     },
     "@highlight-run/node": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@highlight-run/node/-/node-2.5.2.tgz",
-      "integrity": "sha512-/UbU8Zqb7GrMV7Ldc0VvomUK4nPJ+ZjQnU7WQUWEjepE0EGTPB4fSP8eS69S0/OUjC8Z9I/OZqAvUCepkPznQg==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@highlight-run/node/-/node-2.5.3.tgz",
+      "integrity": "sha512-dTAiYSiU+kIDKxRzODzlfSeIUj7xfJtabzMNO2zl22FK3V5n6TPJ4LhfOB0efNiO+avjCEcrdSe/bcTwclHeyQ==",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.3.0",
         "@opentelemetry/auto-instrumentations-node": "0.32.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "@jamesqquick",
   "license": "ISC",
   "dependencies": {
-    "@highlight-run/node": "^2.5.2",
+    "@highlight-run/node": "^2.5.3",
     "@sendgrid/mail": "^7.7.0",
     "@supabase/supabase-js": "^2.1.3",
     "airtable": "^0.10.1",

--- a/src/server/routes/serverInsights.ts
+++ b/src/server/routes/serverInsights.ts
@@ -26,7 +26,6 @@ router.get('/async', async (req: Request, res: Response) => {
   try {
     retVal.body.data = { totalMembers: getMembers() };
   } catch (error) {
-    console.error(error);
     retVal.status = 500;
     retVal.body.err = 'Something went wrong :(';
     const parsedHeaders = H.parseHeaders(req.headers);


### PR DESCRIPTION
Hey @jamesqquick, updating the node.js SDK version to a new one we've released
that fixes an issue where `console.error` statements were not reporting
their stacktrace to highlight for `Errors` visualization.
Removes the `console.error(...)` print which creates duplicate `Error` objects in highlight.